### PR TITLE
Update "debug" dependency to ^4.3.5 via resolutions

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,5 +16,8 @@
   },
   "repository": "git@github.com:maxcanna/antaresbot.git",
   "author": "Massimiliano Cannarozzo <massi@massi.dev>",
-  "license": "MIT"
+  "license": "MIT",
+  "resolutions": {
+    "debug": "^4.3.5"
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -214,13 +214,7 @@ data-uri-to-buffer@^6.0.2:
   resolved "https://registry.yarnpkg.com/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz#8a58bb67384b261a38ef18bea1810cb01badd28b"
   integrity sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==
 
-debug@4:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
-  dependencies:
-    ms "^2.1.1"
-
-debug@^4.1.1, debug@^4.3.4, debug@^4.4.0, debug@^4.4.1:
+debug@4, debug@^4.1.1, debug@^4.3.4, debug@^4.3.5, debug@^4.4.0, debug@^4.4.1:
   version "4.4.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.4.1.tgz#e5a8bc6cbc4c6cd3e64308b0693a3d4fa550189b"
   integrity sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==
@@ -559,10 +553,6 @@ mitt@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/mitt/-/mitt-3.0.1.tgz#ea36cf0cc30403601ae074c8f77b7092cdab36d1"
   integrity sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==
-
-ms@^2.1.1:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
 
 ms@^2.1.3:
   version "2.1.3"


### PR DESCRIPTION
Addresses CVE-2017-16137 / GHSA-gxpj-cx7g-858c by ensuring the "debug" transitive dependency is resolved to a non-vulnerable version.

I've added a resolution for `debug`: "^4.3.5" in package.json. This forces all instances of the `debug` package to use version 4.4.1 (or later compatible), which is above the required 4.3.1 threshold.

The yarn.lock file has been updated accordingly.